### PR TITLE
Handle oversized Firehose batches

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesisanalytics/flink/connectors/producer/impl/FirehoseProducer.java
+++ b/src/main/java/com/amazonaws/services/kinesisanalytics/flink/connectors/producer/impl/FirehoseProducer.java
@@ -295,7 +295,6 @@ public class FirehoseProducer<O extends UserRecordResult, R extends Record> impl
         }
     }
 
-    // returns whether or not all provided Records could be sent to Firehose
     private void submitBatchWithRetry(final Collection<Record> records) throws AmazonKinesisFirehoseException,
             RecordCouldNotBeSentException {
 

--- a/src/test/java/com/amazonaws/services/kinesisanalytics/flink/connectors/producer/FlinkKinesisFirehoseProducerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesisanalytics/flink/connectors/producer/FlinkKinesisFirehoseProducerTest.java
@@ -219,26 +219,6 @@ public class FlinkKinesisFirehoseProducerTest {
     }
 
     @Test
-    public void testFlinkKinesisFirehoseProducerFlushesByteLimit() throws Exception {
-        // Firehose limit is 4MB
-        String longRecord = StringUtils.repeat("*", (int) 5e6);
-        when(firehoseProducer.addUserRecord(new Record().withData(ByteBuffer.wrap(longRecord.getBytes()))))
-        // when(firehoseProducer.addUserRecord(any(Record.class)))
-                .thenReturn(getUserRecordResult(false, true));
-
-        doNothing().when(firehoseProducer).flush();
-
-        when(firehoseProducer.getOutstandingRecordsCount()).thenReturn(1).thenReturn(0);
-        when(firehoseProducer.isFlushFailed()).thenReturn(false);
-
-        flinkKinesisFirehoseProducer.open(properties);
-        flinkKinesisFirehoseProducer.invoke(longRecord, context);
-        flinkKinesisFirehoseProducer.close();
-
-        verify(firehoseProducer, times(1)).flush();
-    }
-
-    @Test
     public void testFlinkKinesisFirehoseProducerTakeSnapshotHappyWorkflow() throws Exception {
 
         when(firehoseProducer.addUserRecord(any(Record.class)))


### PR DESCRIPTION
This addresses an issue where the `FirehoseProducer` fails to flush its buffer because the total size of enqueued records exceeds the Firehose limit. This is important because the recommended action as noted in the current code comments, `reduce your batch size by passing  "FIREHOSE_PRODUCER_BUFFER_MAX_SIZE" into your configuration`, is unreasonable for many cases.

For example, consider data with a wide variance in size. Suppose the producer receives records with the following sizes: `[1MB, 20KB, 5KB, 1MB, 1MB, ..., 1MB]`

The 4 large `1MB` outliers will cause the producer to fail to flush.

To be totally safe, the current approach means library consumers must ensure that the max record size times the buffer size is less than the firehose batch limit. For the data above, this would mean the buffer size could be only `4` (since `1MB` is the max size for an individual firehose record). In general, the buffer size would be the `4 MB / {maximum possible record size}`

This PR adds the ability to retry large batches of records by splitting oversized batches in half and retrying until they succeed. Gives up if a batch consists of only 1 record.

Tested manually on a flink app which uses this connector and via the added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
