### PR TITLE
Fix issue when region enum values are not available for new regions

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesisanalytics/flink/connectors/util/AWSUtil.java
+++ b/src/main/java/com/amazonaws/services/kinesisanalytics/flink/connectors/util/AWSUtil.java
@@ -19,7 +19,6 @@
 package com.amazonaws.services.kinesisanalytics.flink.connectors.util;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kinesisanalytics.flink.connectors.config.AWSConfigConstants;
 import com.amazonaws.services.kinesisanalytics.flink.connectors.provider.credential.CredentialProvider;
 import com.amazonaws.services.kinesisfirehose.AmazonKinesisFirehose;
@@ -66,7 +65,7 @@ public final class AWSUtil {
         final String firehoseEndpointSigningRegion = configProps.getProperty(
             AWS_KINESIS_FIREHOSE_ENDPOINT_SIGNING_REGION, null);
 
-        firehoseClientBuilder = (region != null) ? firehoseClientBuilder.withRegion(Regions.fromName(region))
+        firehoseClientBuilder = (region != null) ? firehoseClientBuilder.withRegion(region)
             : firehoseClientBuilder.withEndpointConfiguration(
             new AwsClientBuilder.EndpointConfiguration(firehoseEndpoint, firehoseEndpointSigningRegion));
 


### PR DESCRIPTION

*Issue #, if available:*

The use of Regions enum in this class is causing issue if we run the code in new regions when the [aws-sdk-java](https://github.com/aws/aws-sdk-java/blob/1.12.403/aws-java-sdk-core/src/main/java/com/amazonaws/regions/Regions.java) is not updated as values for new regions are not available.

*Description of changes:*

Remove the use of Region enum, and use string representation of region directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
